### PR TITLE
Add NumberBoxFloat

### DIFF
--- a/ExtendedControls/Controls/NumberBox.cs
+++ b/ExtendedControls/Controls/NumberBox.cs
@@ -185,6 +185,36 @@ namespace ExtendedControls
         #endregion
     }
 
+    public class NumberBoxFloat : NumberBox<float>
+    {
+        public NumberBoxFloat()
+        {
+            ValueNoChange = 0;
+            Minimum = float.MinValue;
+            Maximum = float.MaxValue;
+        }
+
+        protected override string ConvertToString(float v)
+        {
+            return v.ToString(Format, FormatCulture);
+        }
+        protected override bool ConvertFromString(string t, out float number)
+        {
+            bool ok = float.TryParse(t, System.Globalization.NumberStyles.Float, FormatCulture, out number) &&
+                      number >= Minimum && number <= Maximum;
+            if (ok && othernumber != null)
+                ok = number.CompareTo(othernumber.Value, othercomparision);
+            return ok;
+        }
+
+        protected override bool AllowedChar(char c)
+        {
+            return (char.IsDigit(c) || c == 8 ||
+                    (c == FormatCulture.NumberFormat.CurrencyDecimalSeparator[0] && Text.IndexOf(FormatCulture.NumberFormat.CurrencyDecimalSeparator, StringComparison.Ordinal) == -1) ||
+                    (c == FormatCulture.NumberFormat.NegativeSign[0] && SelectionStart == 0 && Minimum < 0));
+        }
+    }
+
     public class NumberBoxDouble : NumberBox<double>
     {
         public NumberBoxDouble()


### PR DESCRIPTION
I am not sure why this NumberBox is not available/used right now, but this adds the `NumberBox<float>` type with the respective overrides.

Basically a copy of `NumberBox<double>`.

Or do you prefer using `NumberBoxDouble` everywhere and casting it to float on assignment?
Like
```
float myfloat = (float)textBox_withFloat.Value;
```
I am not proficient in C# to see if this might have some intended side effects when the user adds a number not respecting the float limits in the UI.

EDIT:
This could of course also be combined into a `NumberBoxFloatingPoint<T>` with lots of code deduplication. The other boxes would then be created by `NumberBoxDouble : NumberBoxFloatingPoint<double>` and `NumberBoxFloat : NumberBoxFloatingPoint<float>`. Do you prefer this?