### PR TITLE
Added .Trim() to user inputs on trigger condition config form

### DIFF
--- a/ExtendedForms/ConditionForms/ConditionFilterUC.cs
+++ b/ExtendedForms/ConditionForms/ConditionFilterUC.cs
@@ -579,9 +579,9 @@ namespace ExtendedConditionsForms
                         for (int i = 0; i < g.condlist.Count; i++)
                         {
                             Group.Conditions c = g.condlist[i];
-                            string fieldn = c.fname.Text;
+                            string fieldn = c.fname.Text.Trim();
                             string condn = c.cond.Text;
-                            string valuen = c.value.Text;
+                            string valuen = c.value.Text.Trim();
 
                             if (fieldn.Length > 0 || ConditionEntry.IsNullOperation(condn))
                             {


### PR DESCRIPTION
If users copy/paste text into this form and they don't notice a leading or trailing space (mostly trailing spaces) then the condition will not match what is being seen from the game. This change trims any whitespace from the two user editable elements of the trigger condition so that there's a lower likelihood of a mismatch in the string comparison when switching profiles.